### PR TITLE
feat: Use default URLLoaderFactory if protocal handler was callbacked…

### DIFF
--- a/shell/browser/net/electron_url_loader_factory.h
+++ b/shell/browser/net/electron_url_loader_factory.h
@@ -25,6 +25,8 @@
 
 namespace electron {
 
+const uint32_t kBypassCustomProtocolHandlers = 1 << 30;
+
 // Old Protocol API can only serve one type of response for one scheme.
 enum class ProtocolType {
   kBuffer,

--- a/shell/browser/net/proxying_url_loader_factory.h
+++ b/shell/browser/net/proxying_url_loader_factory.h
@@ -38,8 +38,6 @@
 
 namespace electron {
 
-const uint32_t kBypassCustomProtocolHandlers = 1 << 30;
-
 // This class is responsible for following tasks when NetworkService is enabled:
 // 1. handling intercepted protocols;
 // 2. implementing webRequest module;

--- a/spec/api-protocol-spec.ts
+++ b/spec/api-protocol-spec.ts
@@ -26,6 +26,7 @@ const interceptStringProtocol = protocol.interceptStringProtocol;
 const interceptBufferProtocol = protocol.interceptBufferProtocol;
 const interceptHttpProtocol = protocol.interceptHttpProtocol;
 const interceptStreamProtocol = protocol.interceptStreamProtocol;
+const interceptProtocol: (scheme: string, handler: (req: Electron.ProtocolRequest, callback: (res?: Electron.ProtocolResponse) => void) => void) => boolean = protocol.interceptProtocol;
 const unregisterProtocol = protocol.unregisterProtocol;
 const uninterceptProtocol = protocol.uninterceptProtocol;
 
@@ -747,6 +748,78 @@ describe('protocol module', () => {
       });
       const r = await ajax('http://fake-host', { type: 'POST', data: postData });
       expect(r.data).to.equal('GET');
+    });
+  });
+
+  describe('protocol.interceptProtocol', () => {
+    const text = 'Hi, Chaofan!';
+    it('callback with null can behave like no intercept', async () => {
+      const server = http.createServer((req, res) => {
+        res.end(text);
+      });
+      after(() => server.close());
+      const { url } = await listen(server);
+      interceptProtocol('http', (req, callback) => {
+        callback();
+      });
+      await contents.loadURL(url);
+      expect(await contents.executeJavaScript('document.documentElement.textContent')).to.equal(text);
+    });
+
+    it('callback with {data} can response directly', async () => {
+      interceptProtocol('http', (req, callback) => {
+        callback({
+          data: 'hello'
+        });
+      });
+      await contents.loadURL('http://foo');
+      expect(await contents.executeJavaScript('document.documentElement.textContent')).to.equal('hello');
+    });
+
+    it('callback with null can behave like no intercept - redirect case', async () => {
+      const server = http.createServer((req, res) => {
+        if (req.url === '/serverRedirect') {
+          console.log(req.rawHeaders);
+          res.statusCode = 301;
+          res.setHeader('Location', `${url}/foo`);
+          res.end();
+        } else {
+          res.end(text);
+        }
+      });
+      after(() => server.close());
+      const { url } = await listen(server);
+      interceptProtocol('http', (req, callback) => {
+        callback();
+      });
+      await contents.loadURL(`${url}/serverRedirect`);
+      // Redirect should change the page url if not We may met the situation that returns data from page B to page A.
+      expect(await contents.getURL()).to.equal(`${url}/foo`);
+      expect(await contents.executeJavaScript('document.documentElement.textContent')).to.equal(text);
+    });
+
+    it('callback with null can behave like no intercept - post case', async () => {
+      const server = http.createServer((req, res) => {
+        let body = '';
+        req.on('data', (chunk) => {
+          body += chunk;
+        });
+        req.on('end', () => {
+          console.log(body);
+          res.end(body);
+        });
+      });
+      after(() => server.close());
+      const { url } = await listen(server);
+      interceptProtocol('http', (req, callback) => {
+        callback();
+      });
+
+      const r = await ajax(url, {
+        method: 'POST',
+        body: text
+      });
+      expect(r.data).to.equal(text);
     });
   });
 


### PR DESCRIPTION
… without argument.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/electron/electron/blob/main/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [ ] relevant documentation, tutorials, templates and examples are changed or added
- [ ] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes, or 'none' if no notes relevant to app developers. Examples and help on special cases: https://github.com/electron/clerk/blob/main/README.md#examples -->
